### PR TITLE
Fix playback not starting next track at the right time

### DIFF
--- a/src/SpotifyPlayback/SpotifyPlaybackHostedService.cs
+++ b/src/SpotifyPlayback/SpotifyPlaybackHostedService.cs
@@ -60,13 +60,8 @@ namespace SpotifyPlayback
         {
             Task.Run(async () =>
             {
-                var firstTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
-                var secondTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
-                
-                secondTrack.DueTime = DateTime.Now + TimeSpan.FromMilliseconds(firstTrack.SpotifyTrack.TrackDurationMs);
-                
-                _playbackScheduledTrackQueue.AddPlaybackScheduledTrack(secondTrack);
-                await _spotifyPlaybackController.PlaySpotifyTrackForUsers(firstTrack);
+                var nextTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
+                await PlayScheduledTrack(nextTrack);
             });
         }
 

--- a/src/SpotifyPlayback/SpotifyPlaybackHostedService.cs
+++ b/src/SpotifyPlayback/SpotifyPlaybackHostedService.cs
@@ -63,7 +63,7 @@ namespace SpotifyPlayback
                 var firstTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
                 var secondTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
                 
-                secondTrack.DueTime = DateTime.Now + TimeSpan.FromMilliseconds(secondTrack.SpotifyTrack.TrackDurationMs);
+                secondTrack.DueTime = DateTime.Now + TimeSpan.FromMilliseconds(firstTrack.SpotifyTrack.TrackDurationMs);
                 
                 _playbackScheduledTrackQueue.AddPlaybackScheduledTrack(secondTrack);
                 await _spotifyPlaybackController.PlaySpotifyTrackForUsers(firstTrack);
@@ -73,7 +73,7 @@ namespace SpotifyPlayback
         private async Task PlayScheduledTrack(PlaybackScheduledTrack playbackScheduledTrack)
         {
             var groupNewTrack = await _playbackGroupCollection.GetGroupNewTrack(playbackScheduledTrack.GroupId);
-            groupNewTrack.DueTime = DateTime.Now + TimeSpan.FromMilliseconds(groupNewTrack.SpotifyTrack.TrackDurationMs);
+            groupNewTrack.DueTime = DateTime.Now + TimeSpan.FromMilliseconds(playbackScheduledTrack.SpotifyTrack.TrackDurationMs);
             
             _playbackScheduledTrackQueue.AddPlaybackScheduledTrack(groupNewTrack);
             await _spotifyPlaybackController.PlaySpotifyTrackForUsers(playbackScheduledTrack);

--- a/src/SpotifyPlayback/SpotifyPlaybackHostedService.cs
+++ b/src/SpotifyPlayback/SpotifyPlaybackHostedService.cs
@@ -60,13 +60,13 @@ namespace SpotifyPlayback
         {
             Task.Run(async () =>
             {
-                var newTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
-                var nextNewTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
+                var firstTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
+                var secondTrack = await _playbackGroupCollection.GetGroupNewTrack(eventArgs.GroupId);
                 
-                nextNewTrack.DueTime = DateTime.Now + TimeSpan.FromMilliseconds(nextNewTrack.SpotifyTrack.TrackDurationMs);
-                // nextNewTrack.DueTime = DateTime.Now + TimeSpan.FromSeconds(5);
+                secondTrack.DueTime = DateTime.Now + TimeSpan.FromMilliseconds(secondTrack.SpotifyTrack.TrackDurationMs);
                 
-                await PlayScheduledTrack(newTrack);
+                _playbackScheduledTrackQueue.AddPlaybackScheduledTrack(secondTrack);
+                await _spotifyPlaybackController.PlaySpotifyTrackForUsers(firstTrack);
             });
         }
 
@@ -74,7 +74,7 @@ namespace SpotifyPlayback
         {
             var groupNewTrack = await _playbackGroupCollection.GetGroupNewTrack(playbackScheduledTrack.GroupId);
             groupNewTrack.DueTime = DateTime.Now + TimeSpan.FromMilliseconds(groupNewTrack.SpotifyTrack.TrackDurationMs);
-            // groupNewTrack.DueTime = DateTime.Now + TimeSpan.FromSeconds(5);
+            
             _playbackScheduledTrackQueue.AddPlaybackScheduledTrack(groupNewTrack);
             await _spotifyPlaybackController.PlaySpotifyTrackForUsers(playbackScheduledTrack);
         }


### PR DESCRIPTION
In this PR I've fixed  the playback not correctly playing the next track at the right time. 

This was fixed by setting the dueTime of the track to be scheduled based on the duration of the track that will be played. 