### PR TITLE
Fix playback getting stuck at end of track

### DIFF
--- a/src/SpotifyPlayback/Interfaces/ISpotifyPlaybackController.cs
+++ b/src/SpotifyPlayback/Interfaces/ISpotifyPlaybackController.cs
@@ -6,6 +6,5 @@ namespace SpotifyPlayback.Interfaces
     public interface ISpotifyPlaybackController
     {
         Task PlaySpotifyTrackForUsers(PlaybackScheduledTrack spotifyScheduledTrack);
-        Task PauseSpotifyPlayerUser();
     }
 }

--- a/src/SpotifyPlayback/Services/SpotifyPlaybackController.cs
+++ b/src/SpotifyPlayback/Services/SpotifyPlaybackController.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using SpotifyPlayback.Interfaces;
 using SpotifyPlayback.Models;
 using SpotifyPlayback.Models.Socket;
@@ -11,20 +9,18 @@ namespace SpotifyPlayback.Services
     public class SpotifyPlaybackController : ISpotifyPlaybackController
     {
         private readonly IPlaybackGroupCollection _playbackGroupCollection;
-        private readonly IServiceProvider _serviceProvider;
         private readonly ISocketDirector _socketDirector;
+        private readonly ISpotifyPlaybackService _spotifyPlaybackService;
 
-        public SpotifyPlaybackController(IPlaybackGroupCollection playbackGroupCollection, IServiceProvider serviceProvider, ISocketDirector socketDirector)
+        public SpotifyPlaybackController(IPlaybackGroupCollection playbackGroupCollection, ISocketDirector socketDirector, ISpotifyPlaybackService spotifyPlaybackService)
         {
             _playbackGroupCollection = playbackGroupCollection;
-            _serviceProvider = serviceProvider;
             _socketDirector = socketDirector;
+            _spotifyPlaybackService = spotifyPlaybackService;
         }
         
         public Task PlaySpotifyTrackForUsers(PlaybackScheduledTrack playbackScheduledTrack)
         {
-            var spotifyPlaybackService = CreateSpotifyPlaybackService();
-
             var listeners = _playbackGroupCollection.GetGroupListeners(playbackScheduledTrack.GroupId);
             var connectedIds = _playbackGroupCollection.GetGroupJoinedConnectionIds(playbackScheduledTrack.GroupId);
 
@@ -32,16 +28,8 @@ namespace SpotifyPlayback.Services
 
             _socketDirector.BroadCastMessageOverConnections(playbackUpdateMessage, connectedIds);
 
-            return spotifyPlaybackService.PlayNextTrackForUsers(listeners.ToArray(), playbackScheduledTrack.SpotifyTrack.SpotifyTrackId);
+            return _spotifyPlaybackService.PlayNextTrackForUsers(listeners.ToArray(), playbackScheduledTrack.SpotifyTrack.SpotifyTrackId);
         }
-
-        private ISpotifyPlaybackService CreateSpotifyPlaybackService()
-        {
-            using var scope = _serviceProvider.CreateScope();
-            var spotifyPlaybackService = scope.ServiceProvider.GetRequiredService<ISpotifyPlaybackService>();
-            return spotifyPlaybackService;
-        }
-        
         private SocketMessage<PlaybackUpdateMessageBody> CreatePlaybackUpdateMessage(PlaybackScheduledTrack playbackScheduledTrack)
         {
             var playbackGroupInfo = _playbackGroupCollection.GetPlaybackGroupInfo(playbackScheduledTrack.GroupId);
@@ -56,11 +44,6 @@ namespace SpotifyPlayback.Services
                 }
             };
             return playbackUpdateMessage;
-        }
-
-        public Task PauseSpotifyPlayerUser()
-        {
-            throw new System.NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
In this PR I've fixed the issue where the playback was getting stuck at the end of a track. This was because of a disposed dependency in the SpotifyPlaybackController. To fix this I've made sure the SpotifyPlaybackController is created from the ServiceProvider in the hosted service, each time it is being used. 

In this PR I also saw that the queued tracks weren't added to the playback-info that the user receives after a new track is being played. So I've added that aswell.