### PR TITLE
Fix 

### DIFF
--- a/src/Pjfm.Bff/ClientApp/angular.json
+++ b/src/Pjfm.Bff/ClientApp/angular.json
@@ -23,7 +23,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/ClientApp",
+            "outputPath": "dist",
             "index": "src/index.html",
             "main": "src/main.ts",
             "stylePreprocessorOptions": {

--- a/src/Pjfm.Bff/ClientApp/src/app/app.module.ts
+++ b/src/Pjfm.Bff/ClientApp/src/app/app.module.ts
@@ -50,6 +50,10 @@ export function initializeApplication(userService: UserService, permissionConfig
     { provide: API_BASE_URL, useValue: '' },
     FormBuilder,
     UserClient,
+    {
+      provide: API_BASE_URL,
+      useValue: '',
+    },
   ],
   bootstrap: [AppComponent],
 })

--- a/src/Pjfm.Bff/ClientApp/src/app/core/services/api-socket-client.service.ts
+++ b/src/Pjfm.Bff/ClientApp/src/app/core/services/api-socket-client.service.ts
@@ -19,8 +19,7 @@ export class ApiSocketClientService {
   private readonly _playbackData$: Observable<PlaybackUpdateMessageBody | null> = this._playbackData.asObservable();
 
   initializeConnection(): void {
-    // TODO: set the connection through the bff
-    this.socket = webSocket('wss://localhost:5004/api/playback/ws');
+    this.socket = webSocket('/api/playback/ws');
     this.socket.subscribe(
       (message) => {
         this.handleIncomingMessage(message as PlaybackMessage<unknown>);

--- a/src/Pjfm.Bff/Startup.cs
+++ b/src/Pjfm.Bff/Startup.cs
@@ -37,9 +37,11 @@ namespace Pjfm.Bff
             app.UseRouting();
             app.UseCors();
 
-            // app.UseMiddleware<StrictSameSiteExternalAuthenticationMiddleware>();
+            app.UseMiddleware<StrictSameSiteExternalAuthenticationMiddleware>();
             app.UseAuthentication();
             app.UseAuthorization();
+            
+            app.UseSpaStaticFiles();
 
             app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
 


### PR DESCRIPTION
In this PR I've made fixed some issues to make the frontend deployable with the frontend. This includes some configuration and also adding using static files to serve the ClientApp in production.

**Changes**
- Add `UseStaticFiles` in the Bff startup to start serving the ClientApp in production.
- Changed the output path of the ClientApp to `~/ClientApp/dist` instead of `~/ClientApp/dist/ClientApp` which didn't make much sense.
- Set the urls for the api-client and the socket-client to the host base address.
  - Api requests all get proxied to the API from the BFF..